### PR TITLE
Create silent instance of BugSplatLogger if none exists.

### DIFF
--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -17,7 +17,11 @@ export class BugSplat {
 
   constructor(private config: BugSplatConfiguration,
     private http: HttpClient,
-    private logger: BugSplatLogger = new BugSplatLogger()) { }
+    private logger: BugSplatLogger = new BugSplatLogger) {
+      if(!this.logger) {
+        this.logger = new BugSplatLogger();
+      }
+    }
 
   getObservable() {
     return this.bugSplatPostEventSubject.asObservable();


### PR DESCRIPTION
 With optional dependency injection logger can be null and thus the default parameter won't be used.